### PR TITLE
Rails 6.0 compatibility: update_attributes! -> update!

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Gem Version](https://badge.fury.io/rb/the_sortable_tree.png)](http://badge.fury.io/rb/the_sortable_tree) [![Code Climate](https://codeclimate.com/github/the-teacher/the_sortable_tree.png)](https://codeclimate.com/github/the-teacher/the_sortable_tree)
 
-> tested with rails 4.1.0rc2 + haml 4
+- Originally tested with rails 4.1.0rc2 + haml 4
+- Production tested with Rails 5.2.x
+- Updated for Rails 6.x compatibility
 
 Nested Set + Drag&Drop GUI. Very fast! Best render helper! **2000 nodes/sec**. Ready for rails 4 ([RubyGems](http://rubygems.org/gems/the_sortable_tree))
 

--- a/lib/the_sortable_tree/backends/ancestry.rb
+++ b/lib/the_sortable_tree/backends/ancestry.rb
@@ -6,17 +6,17 @@ module TheSortableTree
           self.the_sortable_tree_sort_order = 'ancestry, id'
 
           def move_to_child_of(parent)
-            self.update_attributes! parent_id: parent.id
+            self.update! parent_id: parent.id
           end
 
           # ancestry has no order (other than id), only care about nesting here
 
           def move_to_right_of(other)
-            self.update_attributes! parent_id: other.parent_id
+            self.update! parent_id: other.parent_id
           end
 
           def move_to_left_of(other)
-            self.update_attributes! parent_id: other.parent_id
+            self.update! parent_id: other.parent_id
           end
         end
       end

--- a/lib/the_sortable_tree/backends/ancestry_acts_as_list.rb
+++ b/lib/the_sortable_tree/backends/ancestry_acts_as_list.rb
@@ -14,7 +14,7 @@ module TheSortableTree
           def move_to_child_of(parent)
             transaction do
               remove_from_list
-              self.update_attributes! parent: parent
+              self.update! parent: parent
               add_to_list_bottom
               save!
             end
@@ -24,7 +24,7 @@ module TheSortableTree
             transaction do
               remove_from_list
               other.reload # things may have changed in this list
-              self.update_attributes! parent_id: other.parent_id
+              self.update! parent_id: other.parent_id
               new_position = other.position
               increment_positions_on_lower_items(new_position)
               other.reload
@@ -36,7 +36,7 @@ module TheSortableTree
             transaction do
               remove_from_list
               other.reload # things may have changed in this list
-              self.update_attributes! parent_id: other.parent_id
+              self.update! parent_id: other.parent_id
               if new_position = other.lower_item.try(:position)
                 increment_positions_on_lower_items(new_position)
                 self.update_attribute :position, new_position


### PR DESCRIPTION
Using `ActiveRecord::Base#update_attributes!` is deprecated and will be removed in Rails 6.1. The new recommendation is to use `ActiveRecord::Base#update!` instead.

I tried to get the tests to run, but honestly they are an absolute mess. Linking our own application against my local copy of this branch makes the deprecations disappear and causes no new errors. I'd say that's probably enough effort behind a relatively simple patch such as this.